### PR TITLE
Updating GitHub providers

### DIFF
--- a/examples/github/example_repo.tf
+++ b/examples/github/example_repo.tf
@@ -22,10 +22,10 @@ module "example_repo" {
   }
 
   branches_to_protect = {
-    "some-other-main" = {
+    "main" = {
       enforce_admins                  = false
       up_to_date                      = true
-      status_check_contexts           = ["test", "codeclimate"]
+      status_check_contexts           = ["travis-ci", "codeclimate"]
       require_code_owner_reviews      = false
       required_approving_review_count = 0
       require_signed_commits          = false

--- a/examples/github/example_repo.tf
+++ b/examples/github/example_repo.tf
@@ -22,15 +22,27 @@ module "example_repo" {
   }
 
   branches_to_protect = {
-    "main" = {
-      enforce_admins        = false
-      up_to_date            = true
-      status_check_contexts = ["test", "codeclimate"]
+    "some-other-main" = {
+      enforce_admins                  = false
+      up_to_date                      = true
+      status_check_contexts           = ["test", "codeclimate"]
+      require_code_owner_reviews      = false
+      required_approving_review_count = 0
+      require_signed_commits          = false
+      dismiss_stale_reviews           = false
+      push_restrictions               = []
+      dismissal_restrictions          = []
     }
     "other-branch" = {
-      enforce_admins        = false
-      up_to_date            = true
-      status_check_contexts = []
+      enforce_admins                  = false
+      up_to_date                      = true
+      status_check_contexts           = []
+      require_code_owner_reviews      = false
+      required_approving_review_count = 0
+      require_signed_commits          = false
+      dismiss_stale_reviews           = false
+      push_restrictions               = []
+      dismissal_restrictions          = []
     }
   }
 }

--- a/examples/github/example_repo.tf
+++ b/examples/github/example_repo.tf
@@ -1,5 +1,5 @@
 module "example_repo" {
-  # When running locally, use '../../github'
+  # When running locally, use "../../github"
   source = "git@github.com:emmasax4/terraform.git//github?ref=main"
 
   # When running this example, put your own token in here

--- a/github/README.md
+++ b/github/README.md
@@ -23,6 +23,7 @@
 |------|-------------|---------|
 | additional_branches | An optional list of long-lived branch names to add to the repository; the default branch does not need to be in this list | `[]` |
 | archived | Whether the repository should be archived or not; the API does not support unarchiving, so unarchival must happen through the GitHub browser | `false` |
+| archive_on_destroy | Whether or not to archive the repository instead of fully deleting it | `false` |
 | branches_to_protect | An optional list of branches to protect and what the branch protection settings should be; the default branch should be added to this list if desired | `{}` |
 | create_gitignore | Whether to create a new `.gitignore` file | `true` |
 | default_branch | The default branch | `"main"` |
@@ -39,8 +40,9 @@
 | projects | Whether the repository should allow projects | `false` |
 | rebase_commit | Whether the repository should allow rebase commits | `false`
 | repository_name * | The name of the repository to manage | |
-| source_branch | The branch that the new branch's source is from; this should only be used temporarily when adding branches | `"master"` |
+| source_branch | The branch that the new branch's source is from; this should only be used temporarily when adding branches | `"main"` |
 | squash_commit | Whether the repository should allow squash commits | `true` |
+| template | The GitHub repository template that should be used when creating the new repository | `{ owner = "", repository = "" }` |
 | topics | An optional list of topic strings to add to the repository | `[]` |
 | users | An optional list of individual users that should have special permissions | `{}` |
 | visibility | Whether the repository should be private or public | `"private"` |
@@ -59,6 +61,11 @@ module "example_repo" {
   repository_name = "example_repo"
   visibility      = "private"
   description     = "Some random description here"
+
+  template = {
+    owner      = "github"
+    repository = "template"
+  }
 
   users = {
     "github-username"       = { permission = "pull" }
@@ -195,7 +202,7 @@ Change the of the `default_branch` variable in the repository's file. The new de
 
 ### Creating a New Default Branch
 
-If you are creating a new branch, add the `source_branch` variable and set it to be the source of the new branch you're creating, which is most likely the existing default branch (default is `master`).
+If you are creating a new branch, add the `source_branch` variable and set it to be the source of the new branch you're creating, which is most likely the existing default branch (default is `main`).
 
 Run:
 

--- a/github/README.md
+++ b/github/README.md
@@ -85,7 +85,7 @@ module "example_repo" {
     "dev" = {
       enforce_admins        = false
       up_to_date            = true
-      status_check_contexts = ["test", "codeclimate"]
+      status_check_contexts = ["travis-ci", "codeclimate"]
     }
     "publish" = {
       enforce_admins        = false

--- a/github/README.md
+++ b/github/README.md
@@ -42,7 +42,7 @@
 | repository_name * | The name of the repository to manage | |
 | source_branch | The branch that the new branch's source is from; this should only be used temporarily when adding branches | `"main"` |
 | squash_commit | Whether the repository should allow squash commits | `true` |
-| template | The GitHub repository template that should be used when creating the new repository | `{ owner = "", repository = "" }` |
+| template | The optional owner and template repository that the new repository should be based on | `{ owner = "", repository = "" }` |
 | topics | An optional list of topic strings to add to the repository | `[]` |
 | users | An optional list of individual users that should have special permissions | `{}` |
 | visibility | Whether the repository should be private or public | `"private"` |

--- a/github/branch.tf
+++ b/github/branch.tf
@@ -1,6 +1,6 @@
 locals {
-  branches      = setsubtract(distinct(concat(var.additional_branches, [var.source_branch], [var.default_branch])), ["master"])
-  delete_branch = var.default_branch == "master" ? [] : ["master"]
+  branches      = setsubtract(distinct(concat(var.additional_branches, [var.source_branch], [var.default_branch])), ["main"])
+  delete_branch = var.default_branch == "main" ? [] : ["main"]
 }
 
 resource "github_branch" "branch" {
@@ -33,7 +33,7 @@ resource "null_resource" "update_default_branch" {
   }
 }
 
-resource "null_resource" "delete_master_branch" {
+resource "null_resource" "delete_main_branch" {
   for_each = setsubtract(toset(local.delete_branch), local.branches)
 
   depends_on = [
@@ -43,10 +43,10 @@ resource "null_resource" "delete_master_branch" {
   ]
 
   triggers = {
-    branch_to_delete = "master"
+    branch_to_delete = "main"
   }
 
   provisioner "local-exec" {
-    command = "curl -H 'Authorization: token ${var.github_token}' -X DELETE https://api.github.com/repos/${var.owner}/${github_repository.repo.name}/git/refs/heads/master"
+    command = "curl -H 'Authorization: token ${var.github_token}' -X DELETE https://api.github.com/repos/${var.owner}/${github_repository.repo.name}/git/refs/heads/main"
   }
 }

--- a/github/branch_protection.tf
+++ b/github/branch_protection.tf
@@ -1,15 +1,24 @@
-# resource "github_branch_protection" "branch_protection" {
-#   for_each       = var.branches_to_protect
-#   repository     = github_repository.repo.name
-#   branch         = each.key
-#   enforce_admins = each.value.enforce_admins
+resource "github_branch_protection" "branch_protection" {
+  for_each               = var.branches_to_protect
+  repository_id          = github_repository.repo.node_id
+  pattern                = each.key
+  enforce_admins         = each.value.enforce_admins
+  require_signed_commits = each.value.require_signed_commits
+  push_restrictions      = each.value.push_restrictions
 
-#   required_status_checks {
-#     strict   = each.value.up_to_date
-#     contexts = each.value.status_check_contexts
-#   }
+  required_status_checks {
+    strict   = each.value.up_to_date
+    contexts = each.value.status_check_contexts
+  }
 
-#   depends_on = [
-#     github_branch.branch
-#   ]
-# }
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = each.value.dismiss_stale_reviews
+    dismissal_restrictions          = each.value.dismissal_restrictions
+    require_code_owner_reviews      = each.value.require_code_owner_reviews
+    required_approving_review_count = each.value.required_approving_review_count == 0 ? 1 : each.value.required_approving_review_count
+  }
+
+  depends_on = [
+    github_branch.branch
+  ]
+}

--- a/github/main.tf
+++ b/github/main.tf
@@ -1,5 +1,5 @@
 provider "github" {
   token   = var.github_token
   owner   = var.owner
-  version = "~> 3.0.0"
+  version = "~> 3.1.0"
 }

--- a/github/repository.tf
+++ b/github/repository.tf
@@ -1,5 +1,6 @@
 locals {
-  topics = concat(var.topics, ["managed-by-terraform"])
+  topics   = concat(var.topics, ["managed-by-terraform"])
+  template = length(var.template["owner"]) > 0 && length(var.template["repository"]) > 0 ? [var.template] : []
 }
 
 resource "github_repository" "repo" {
@@ -19,6 +20,15 @@ resource "github_repository" "repo" {
   allow_rebase_merge     = var.rebase_commit
   delete_branch_on_merge = var.delete_branch_on_merge
   auto_init              = true
+  archive_on_destroy     = var.archive_on_destroy
+
+  dynamic "template" {
+    for_each = local.template
+    content {
+      owner      = var.template["owner"]
+      repository = var.template["repository"]
+    }
+  }
 
   lifecycle {
     ignore_changes = [

--- a/github/variables.tf
+++ b/github/variables.tf
@@ -14,6 +14,18 @@ variable "owner" {
   description = "The GitHub owner (organization or user) this Terraform is running on"
 }
 
+variable "template" {
+  type = object({
+    owner      = string
+    repository = string
+  })
+  default = {
+    owner      = ""
+    repository = ""
+  }
+  description = "A list of ONE template that the repository should be based on"
+}
+
 variable "visibility" {
   type        = string
   default     = "private"
@@ -30,6 +42,12 @@ variable "archived" {
   type        = bool
   default     = false
   description = "Whether the repository should be archived or not; the API does not support unarchiving, so unarchival must happen through the GitHub browser"
+}
+
+variable "archive_on_destroy" {
+  type        = bool
+  default     = false
+  description = "Whether or not to archive the repository instead of fully deleting it"
 }
 
 variable "homepage_url" {
@@ -120,7 +138,7 @@ variable "default_branch" {
 
 variable "source_branch" {
   type        = string
-  default     = "master"
+  default     = "main"
   description = "The branch that the new branch's source is from; this should only be used temporarily when adding branches"
 }
 
@@ -132,9 +150,15 @@ variable "additional_branches" {
 
 variable "branches_to_protect" {
   type = map(object({
-    enforce_admins        = bool
-    up_to_date            = bool
-    status_check_contexts = list(string)
+    enforce_admins                  = bool
+    push_restrictions               = list(string)
+    up_to_date                      = bool
+    status_check_contexts           = list(string)
+    require_signed_commits          = bool
+    dismiss_stale_reviews           = bool
+    dismissal_restrictions          = list(string)
+    require_code_owner_reviews      = bool
+    required_approving_review_count = number # 1–6
   }))
   default     = {}
   description = "An optional list of branches to protect and what the branch protection settings should be; the default branch should be added to this list if desired"

--- a/github/variables.tf
+++ b/github/variables.tf
@@ -23,7 +23,7 @@ variable "template" {
     owner      = ""
     repository = ""
   }
-  description = "A list of ONE template that the repository should be based on"
+  description = "The optional owner and template repository that the new repository should be based on"
 }
 
 variable "visibility" {
@@ -158,7 +158,7 @@ variable "branches_to_protect" {
     dismiss_stale_reviews           = bool
     dismissal_restrictions          = list(string)
     require_code_owner_reviews      = bool
-    required_approving_review_count = number # 1–6
+    required_approving_review_count = number # 0 if not requiring reviews, otherwise 1–6
   }))
   default     = {}
   description = "An optional list of branches to protect and what the branch protection settings should be; the default branch should be added to this list if desired"


### PR DESCRIPTION
## Changes

Update the GitHub terraform provider to 3.1.0. This now creates the `main` branch on default, so we don't need to create a new branch and delete the `master` branch when the `main` branch is the default branch on a new repository. Also, this now has better enhancements for the branch protection (which was previously commented out but now works like a charm).

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
